### PR TITLE
Fix valule template for google search

### DIFF
--- a/examples/function/google_search/README.md
+++ b/examples/function/google_search/README.md
@@ -24,10 +24,10 @@ Needs Google API Key
     type: rest
     resource_template: "https://www.googleapis.com/customsearch/v1?key=[GOOGLE_API_KEY]&cx=[GOOGLE_PROGRAMMING_SEARCH_ENGINE]:omuauf_lfve&q={{ query }}&num=3"
     value_template: >-
-      {% if value_json.items %}
+      {% if value_json["items"] %}
       ```csv
       title,link
-      {% for item in value_json.items %}
+      {% for item in value_json["items"] %}
       "{{ item.title | replace(',', ' ') }}","{{ item.link }}"
       {% endfor %}
       ```


### PR DESCRIPTION
The existing value template for google search throws an error `TypeError: 'builtin_function_or_method' object is not iterable
` because `.items` is a builtin method. This PR is to fix this issue by using bracket notation.